### PR TITLE
Add brave automatic detection

### DIFF
--- a/src/detection.rs
+++ b/src/detection.rs
@@ -68,6 +68,7 @@ fn get_by_name(options: &DetectionOptions) -> Option<PathBuf> {
         ("google-chrome-unstable", options.unstable),
         ("chromium", true),
         ("chromium-browser", true),
+        ("brave", true),
         ("msedge", options.msedge),
         ("microsoft-edge", options.msedge),
         ("microsoft-edge-stable", options.msedge),


### PR DESCRIPTION
I use your crate as a dependency.
Personally I switched from chromium to brave.
Since then I was unable to test my app and had to manually configure the brave executable path in my app. After some time I thought it would be nice if chromey would be able to do that and I found it can auto detect executables.

Here is the very small change which is roughly tested, but that makes even brave start and work together with chromey.
What do you think?