### PR TITLE
feat(network): push interception policy to remote engines (Interception.setPolicy, default-off)

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -320,6 +320,10 @@ impl Browser {
             max_main_frame_navigations: config.max_main_frame_navigations,
             whitelist_patterns: config.whitelist_patterns.clone(),
             blacklist_patterns: config.blacklist_patterns.clone(),
+            // The local-launch path drives a real Chrome, which ignores the
+            // vendor `Interception.setPolicy` method — so leave it off here.
+            // Remote engines opt in via `HandlerConfig`/`connect_with_config`.
+            remote_local_policy: false,
             #[cfg(feature = "adblock")]
             adblock_filter_rules: config.adblock_filter_rules.clone(),
             channel_capacity: config.channel_capacity,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -534,6 +534,7 @@ impl Handler {
                 extra_headers: self.config.extra_headers.clone(),
                 only_html: self.config.only_html && self.config.created_first_target,
                 intercept_manager: self.config.intercept_manager,
+                remote_local_policy: self.config.remote_local_policy,
                 max_bytes_allowed: self.config.max_bytes_allowed,
                 max_redirects: self.config.max_redirects,
                 max_main_frame_navigations: self.config.max_main_frame_navigations,
@@ -1513,6 +1514,11 @@ pub struct HandlerConfig {
     pub whitelist_patterns: Option<Vec<String>>,
     /// Optional per-run/per-site blacklist of URL substrings (scripts/resources).
     pub blacklist_patterns: Option<Vec<String>>,
+    /// Push the interception policy to a capable remote engine once per
+    /// navigation (`Interception.setPolicy`) so it can resolve block/allow
+    /// locally instead of round-tripping each `Fetch.requestPaused`. Default
+    /// `false`; safe to enable against any target (unknown method is ignored).
+    pub remote_local_policy: bool,
     /// Extra ABP/uBO filter rules for the adblock engine.
     #[cfg(feature = "adblock")]
     pub adblock_filter_rules: Option<Vec<String>>,
@@ -1563,6 +1569,7 @@ impl Default for HandlerConfig {
             max_main_frame_navigations: None,
             whitelist_patterns: None,
             blacklist_patterns: None,
+            remote_local_policy: false,
             #[cfg(feature = "adblock")]
             adblock_filter_rules: None,
             channel_capacity: 4096,

--- a/src/handler/network.rs
+++ b/src/handler/network.rs
@@ -412,6 +412,17 @@ pub struct NetworkManager {
     blacklist_matcher: Option<AhoCorasick>,
     /// If true, blacklist always wins (cannot be unblocked by whitelist/3p allow).
     blacklist_strict: bool,
+    /// When true, push the interception policy (flags + per-job
+    /// blacklist/whitelist + page url) to a capable remote engine once per
+    /// navigation via `Interception.setPolicy`, so it can resolve block/allow
+    /// decisions locally instead of round-tripping each `Fetch.requestPaused`.
+    /// Default `false` — a real Chrome target 200-OK-ignores the unknown
+    /// method, and an engine that does not implement it simply keeps the
+    /// round-trip path, so this is safe to leave on. Carries no engine-
+    /// specific data: only this manager's existing config fields are
+    /// serialized; the per-job lists travel as the opaque strings the caller
+    /// already supplied.
+    remote_local_policy: bool,
     /// Custom adblock engine built from user-supplied filter rules.
     /// When `Some`, takes precedence over the global default engine.
     #[cfg(feature = "adblock")]
@@ -455,6 +466,7 @@ impl NetworkManager {
             blacklist_patterns: Vec::new(),
             blacklist_matcher: None,
             blacklist_strict: true,
+            remote_local_policy: false,
             max_bytes_allowed: None,
             max_redirects: None,
             #[cfg(feature = "_cache")]
@@ -657,6 +669,65 @@ impl NetworkManager {
 
     pub fn set_block_all(&mut self, block_all: bool) {
         self.block_all = block_all;
+    }
+
+    /// Enable/disable pushing the interception policy to a capable remote
+    /// engine (see [`NetworkManager::remote_local_policy`]).
+    pub fn set_remote_local_policy(&mut self, enabled: bool) {
+        self.remote_local_policy = enabled;
+    }
+
+    /// Serialize the current interception configuration into the
+    /// `Interception.setPolicy` params. Pure serialization of fields this
+    /// manager already holds — no engine-specific logic, no list contents
+    /// beyond the caller-supplied per-job substrings.
+    fn request_policy_params(&self) -> serde_json::Value {
+        serde_json::json!({
+            "version": 1,
+            "enabled": true,
+            "flags": {
+                "blockAll": self.block_all,
+                "blockVisuals": self.ignore_visuals,
+                "blockStylesheets": self.block_stylesheets,
+                "blockJavascript": self.block_javascript,
+                "blockAnalytics": self.block_analytics,
+                "blockAds": self.block_ads_enabled(),
+                "blockPrefetch": self.block_prefetch,
+                "onlyHtml": self.only_html,
+                "blacklistStrict": self.blacklist_strict,
+                "allowFirstPartyStylesheets": self.allow_first_party_stylesheets,
+                "allowFirstPartyJavascript": self.allow_first_party_javascript,
+                "allowFirstPartyVisuals": self.allow_first_party_visuals,
+            },
+            "blacklist": self.blacklist_patterns,
+            "whitelist": self.whitelist_patterns,
+            // Discriminant only — a non-default manager signals the engine to
+            // keep the round-trip (the manager's detection stays here).
+            "interceptManager": format!("{:?}", self.intercept_manager),
+            "pageUrl": self.document_target_url,
+        })
+    }
+
+    /// Ad blocking is governed by the `firewall` build (the `block_websites`
+    /// /`detect_ad` path). When that feature is off this manager performs no
+    /// ad blocking, so the pushed policy must report `false` to stay in parity.
+    #[inline]
+    fn block_ads_enabled(&self) -> bool {
+        cfg!(feature = "firewall")
+    }
+
+    /// Push the one-shot `Interception.setPolicy` to the remote engine when
+    /// enabled and Fetch interception is active. No-op otherwise (default), so
+    /// callers that never opt in pay nothing and behavior is unchanged.
+    pub fn emit_request_policy(&mut self) {
+        if !self.remote_local_policy || !self.protocol_request_interception_enabled {
+            return;
+        }
+        let params = self.request_policy_params();
+        self.queued_events.push_back(NetworkEvent::SendCdpRequest((
+            Cow::Borrowed("Interception.setPolicy"),
+            params,
+        )));
     }
 
     pub fn set_request_interception(&mut self, enabled: bool) {
@@ -1277,6 +1348,11 @@ impl NetworkManager {
 
         self.document_target_domain = host_base.to_string();
         self.document_target_url = page_target_url;
+
+        // Re-push the policy on navigation so the remote engine's first-party
+        // origin tracks the new page. No-op unless `remote_local_policy` is on
+        // and interception is active.
+        self.emit_request_policy();
     }
 
     /// Clear the initial target domain on every navigation.
@@ -2212,7 +2288,10 @@ mod tests {
                 }
             }
         }
-        assert!(blocked, "third-party Script-initiated CSS must remain blocked");
+        assert!(
+            blocked,
+            "third-party Script-initiated CSS must remain blocked"
+        );
     }
 
     #[cfg(feature = "adblock")]

--- a/src/handler/parallel/router.rs
+++ b/src/handler/parallel/router.rs
@@ -366,6 +366,7 @@ impl Router {
                 extra_headers: self.config.extra_headers.clone(),
                 only_html: self.config.only_html && self.config.created_first_target,
                 intercept_manager: self.config.intercept_manager,
+                remote_local_policy: self.config.remote_local_policy,
                 max_bytes_allowed: self.config.max_bytes_allowed,
                 max_redirects: self.config.max_redirects,
                 max_main_frame_navigations: self.config.max_main_frame_navigations,

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -225,6 +225,12 @@ impl Target {
         network_manager.allow_first_party_visuals = config.allow_first_party_visuals;
         network_manager.only_html = config.only_html;
         network_manager.intercept_manager = config.intercept_manager;
+        network_manager.set_remote_local_policy(config.remote_local_policy);
+
+        // Push the one-shot interception policy now that every field above is
+        // configured (must run AFTER the field setup — `set_request_interception`
+        // above only queued `Fetch.enable`). No-op unless opted in.
+        network_manager.emit_request_policy();
 
         #[cfg(feature = "adblock")]
         if let Some(rules) = &config.adblock_filter_rules {
@@ -1437,6 +1443,11 @@ pub struct TargetConfig {
     /// Network intercept manager used to make allow/deny/modify decisions
     /// for requests when `request_intercept` is enabled.
     pub intercept_manager: NetworkInterceptManager,
+    /// Push the interception policy to a capable remote engine once per
+    /// navigation (`Interception.setPolicy`) so it resolves block/allow
+    /// locally instead of round-tripping each `Fetch.requestPaused`. Default
+    /// `false`; safe against any target.
+    pub remote_local_policy: bool,
     /// The maximum number of response bytes allowed for this target.
     /// When set, responses larger than this limit may be truncated or aborted.
     pub max_bytes_allowed: Option<u64>,
@@ -1485,6 +1496,7 @@ impl Default for TargetConfig {
             only_html: false,
             extra_headers: Default::default(),
             intercept_manager: NetworkInterceptManager::Unknown,
+            remote_local_policy: false,
             max_bytes_allowed: None,
             max_redirects: None,
             max_main_frame_navigations: None,


### PR DESCRIPTION
## What

Opt-in `remote_local_policy` path on `NetworkManager`. When enabled, the manager serializes its interception config (the `block_*`/`allow_first_party_*` flags + the per-job blacklist/whitelist substrings + page url) and pushes it **once per navigation** via a vendor CDP method `Interception.setPolicy`, so a capable remote rendering engine can resolve block/allow decisions **locally** instead of round-tripping every `Fetch.requestPaused`.

## Why

Against a remote engine, `Fetch.enable "*"` makes every request pause and round-trip twice over the wire (`requestPaused` up, `continue`/`fail`/`fulfill` down) — ~2N messages for an N-subresource page. Pushing the policy once lets the engine skip those round-trips for everything it can decide locally.

## Changes
- `NetworkManager`: `remote_local_policy` field + `set_remote_local_policy`, `request_policy_params()`, `emit_request_policy()` (raw CDP push); emitted after target field setup and re-emitted on `set_page_url` (navigation).
- Threaded `remote_local_policy` through `HandlerConfig` + `TargetConfig` (+ both `TargetConfig` builders). Local-launch `BrowserConfig` path stays `false`.

## Safety
- **Default `false`** → zero extra traffic, byte-identical behavior unless opted in.
- A real Chrome target ignores the unknown method; engines that implement it answer `applied: true`.
- Pure serialization of existing config — carries no engine-specific data; per-job lists travel as the opaque strings the caller already supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)