### PR TITLE
chore(release): chromey 2.50.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chromey"
-version = "2.49.1"
+version = "2.50.0"
 rust-version = "1.70"
 authors = ["j-mendez <jeff@spider.cloud>"]
 edition = "2021"


### PR DESCRIPTION
Release bump for #13 (the opt-in `Interception.setPolicy` push).

`2.49.1 → 2.50.0`. The new public fields on `HandlerConfig` / `TargetConfig` /
`NetworkManager` are additive and default-off, matching the `allow_first_party_*`
precedent (2.49.0) — minor bump.

Verified: `cargo publish --dry-run` packages + verifies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)